### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "duktape"
+description := "An embeddable Javascript engine, with a focus on portability and compact footprint."
+gitrepo     := "https://github.com/svaarala/duktape.git"
+homepage    := "https://duktape.org/"
+version     := 2.4.0 sha256:86a89307d1633b5cedb2c6e56dc86e92679fc34b05be551722d8cc69ab0771fc https://duktape.org/duktape-2.4.0.tar.xz
+license     := "MIT"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

