### PR TITLE
Makefile.uk: Change Python version to Python2

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -79,7 +79,7 @@ DUKTAPE_SRCS-y += $(DUKTAPE_EXTRACTED)/examples/cmdline/duk_cmdline.c
 $(DUKTAPE_BUILD)/.prepared: $(DUKTAPE_BUILD)/.origin
 	$(call build_cmd,CONF,duktape,$@,\
 	cd $(DUKTAPE_EXTRACTED)/ && \
-	python tools/configure.py --output-directory duktape-src -DDUK_USE_FASTINT -UDUK_USE_ES6_PROXY && \
+	python2 tools/configure.py --output-directory duktape-src -DDUK_USE_FASTINT -UDUK_USE_ES6_PROXY && \
 	touch $@)
 
 UK_PREPARE += $(DUKTAPE_BUILD)/.prepared


### PR DESCRIPTION
`tools/configure.py` uses Python2 syntax. If only using `python` as the command, this may cause the use of Python3, and that results in syntax errors. Thus this change enforces the use of `python2`.